### PR TITLE
fix/add-extension-name-to-manifest-json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "name": "<name in manifest.json>",
-  "description": "<description in manifest.json>",
+  "name": "time-tracker",
+  "description": "A simple time tracker Chrome extension",
   "background": {
     "service_worker": "src/pages/background/index.ts",
     "type": "module",
@@ -16,33 +16,17 @@
   "icons": {
     "128": "icon-128.png"
   },
-  "permissions": [
-    "activeTab",
-    "storage",
-    "tabs"
-  ],
+  "permissions": ["activeTab", "storage", "tabs"],
   "content_scripts": [
     {
-      "matches": [
-        "http://*/*",
-        "https://*/*",
-        "<all_urls>"
-      ],
-      "js": [
-        "src/pages/content/index.tsx"
-      ],
-      "css": [
-        "contentStyle.css"
-      ]
+      "matches": ["http://*/*", "https://*/*", "<all_urls>"],
+      "js": ["src/pages/content/index.tsx"],
+      "css": ["contentStyle.css"]
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": [
-        "contentStyle.css",
-        "icon-128.png",
-        "icon-32.png"
-      ],
+      "resources": ["contentStyle.css", "icon-128.png", "icon-32.png"],
       "matches": []
     }
   ]


### PR DESCRIPTION
Edit manifest.json to add name to extension:

<img width="515" alt="image" src="https://github.com/joao-pedrozo/time-tracker/assets/17225358/541f4e60-7a08-403b-9755-ca31aca3d617">
