### PR TITLE
fix/tailwind-preflight-conflict

### DIFF
--- a/src/pages/content/style.css
+++ b/src/pages/content/style.css
@@ -1,6 +1,19 @@
+/* *, ::before, ::after o */
+/* https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally */
+
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-.langin{
+
+*,
+::before,
+::after {
+    border-width: 0;
+    border-style: solid;
+    border-color: transparent;
+}
+
+.langin {
     color: aliceblue;
 }

--- a/src/pages/content/style.css
+++ b/src/pages/content/style.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+/* https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally */
+/* https://github.com/tailwindlabs/tailwindcss/issues/1167#issuecomment-1257033795 */
 *,
 ::before,
 ::after {
@@ -10,8 +12,6 @@
     border-color: transparent;
 }
 
-/* https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally */
-/* https://github.com/tailwindlabs/tailwindcss/issues/1167#issuecomment-1257033795 */
 .langin {
     color: aliceblue;
 }

--- a/src/pages/content/style.css
+++ b/src/pages/content/style.css
@@ -1,7 +1,3 @@
-/* *, ::before, ::after o */
-/* https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally */
-
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -14,6 +10,8 @@
     border-color: transparent;
 }
 
+/* https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally */
+/* https://github.com/tailwindlabs/tailwindcss/issues/1167#issuecomment-1257033795 */
 .langin {
     color: aliceblue;
 }


### PR DESCRIPTION
Fix style conflict with GH files change tab diff element default border 


| Prev | Current |
|--------|--------|
| <img width="1465" alt="image" src="https://github.com/joao-pedrozo/time-tracker/assets/17225358/513fa86c-ee3a-44d1-9022-fbea31bc3613"> | <img width="1491" alt="image" src="https://github.com/joao-pedrozo/time-tracker/assets/17225358/f604f72c-15d2-41bb-8ce1-9ba8c9130032"> | 


Reference 
https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally
https://github.com/tailwindlabs/tailwindcss/issues/1167#issuecomment-1257033795 